### PR TITLE
fixing CYRUS_SASL_LIBRARY on ubuntu jammy 22.04 needed packages libsa…

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,9 @@ Linux
 
 Required:
 
-    sudo apt install git cmake build-essential libssl-dev libncurses-dev libxapian-dev libsqlite3-dev libsasl2-modules libmagic-dev libcurl4-openssl-dev libexpat-dev zlib1g-dev uuid-dev
+    sudo apt install git cmake build-essential libssl-dev libncurses-dev libxapian-dev libsqlite3-dev libsasl2-modules libmagic-dev libcurl4-openssl-dev libexpat-dev zlib1g-dev uuid-dev libsasl2-2 libsasl2-dev
+
+> while compiling on Ubuntu jammy 22.04: you need to install libsasl2-2 libsasl2-dev for _CYRUS_SASL_LIBRARY_
 
 Optional (to view/compose HTML emails):
 


### PR DESCRIPTION
updating README installation on ubuntu.
fixing CYRUS_SASL_LIBRARY on ubuntu jammy22.04 needed packages,