### PR TITLE
Update README.md to add install instructions for Guix

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,10 @@ Gentoo
 
     sudo emerge -n dev-util/cmake dev-libs/openssl sys-libs/ncurses dev-libs/xapian dev-db/sqlite dev-libs/cyrus-sasl net-misc/curl dev-libs/expat sys-libs/zlib sys-apps/file
 
+Guix
+
+    guix install nmail
+
 **Build**
 
     mkdir -p build && cd build && cmake .. && make -s


### PR DESCRIPTION
Works with the Guix package manager, be it installed on Guix system directly, or on a foreign distribution.